### PR TITLE
Remove unnecessary api filters and add encodings for couple of projec…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,11 +6,11 @@ pipeline {
 		timestamps()
 	}
 	agent {
-		label "centos-7"
+		label "centos-latest"
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'openjdk-jdk11-latest'
+		jdk 'openjdk-jdk17-latest'
 	}
 	stages {
 		stage('Build') {
@@ -21,7 +21,6 @@ pipeline {
 					/opt/tools/java/openjdk/jdk-11/latest/bin/java -version
 					java -version
 					
-					df -k
 					mkdir -p $WORKSPACE/tmp
 					
 					unset JAVA_TOOL_OPTIONS
@@ -33,15 +32,13 @@ pipeline {
 					
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 					-Pbuild-individual-bundles -Ptest-on-javase-17 -Pbree-libs -Papi-check \
-					-Djava.io.tmpdir=$WORKSPACE/tmp -Dcompare-version-with-baselines.skip=false -Dproject.build.sourceEncoding=UTF-8 \
-					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17 -Djdt.performance.asserts=disabled" 
+					-Djava.io.tmpdir=$WORKSPACE/tmp -Dcompare-version-with-baselines.skip=true -Dproject.build.sourceEncoding=UTF-8 \
+					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17 -Djdt.performance.asserts=disabled"
 					"""
 				}
 			}
 			post {
 				always {
-					sh"""df -k
-					"""
 					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
 					recordIssues aggregatingResults: true, enabledForFailure: true, qualityGates: [[threshold: 1, type: 'DELTA', unstable: false]], tools: [acuCobol()]
 					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]

--- a/org.eclipse.jdt.core.ecj.validation/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.core.ecj.validation/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -8,15 +8,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="dom/org/eclipse/jdt/core/dom/AST.java" type="org.eclipse.jdt.core.dom.AST">
-        <filter comment="For new java version" id="388194388">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.AST"/>
-                <message_argument value="JLS_Latest"/>
-                <message_argument value="17"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/AbstractTagElement.java" type="org.eclipse.jdt.core.dom.AbstractTagElement">
         <filter id="576725006">
             <message_arguments>
@@ -196,24 +187,6 @@
         </filter>
     </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/TagProperty.java" type="org.eclipse.jdt.core.dom.TagProperty">
-        <filter id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.TagProperty"/>
-                <message_argument value="TAG_PROPERTY_SNIPPET_ID"/>
-            </message_arguments>
-        </filter>
-        <filter id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.TagProperty"/>
-                <message_argument value="TAG_PROPERTY_SNIPPET_INLINE_TAG_COUNT"/>
-            </message_arguments>
-        </filter>
-        <filter id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.TagProperty"/>
-                <message_argument value="TAG_PROPERTY_SNIPPET_REGION_TEXT"/>
-            </message_arguments>
-        </filter>
         <filter id="576725006">
             <message_arguments>
                 <message_argument value="IDocElement"/>

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.30.0.qualifier
+Bundle-Version: 3.30.100.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.30.0-SNAPSHOT</version>
+  <version>3.30.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.tests.latestBREE/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.tests.latestBREE/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,3 @@
 eclipse.preferences.version=1
 encoding//src/org/eclipse/jdt/core/tests/compiler/regression/latest/TextBlockTest.java=UTF-8
+encoding/<project>=UTF-8


### PR DESCRIPTION
…ts (#129)

* Remove unnecessary api filters and add encodings for couple of projects

Removed unnecessary api problem filters and add utf-8 encoding to
ecj.validation and latest BREE projects

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/128